### PR TITLE
update to new minor canned version (0.3.8)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-canned",
-  "version": "0.0.4",
+  "version": "0.1.0",
   "description": "Grunt wrapper around https://github.com/sideshowcoder/canned node module",
   "homepage": "http://github.com/jkjustjoshing/grunt-canned",
   "repository": "http://github.com/jkjustjoshing/grunt-canned",
@@ -29,7 +29,7 @@
     "load-grunt-tasks": "~0.3.0"
   },
   "dependencies": {
-    "canned": "~0.2.2",
+    "canned": "~0.3.8",
     "watch" : ">=0.5.0"
   },
   "scripts": {


### PR DESCRIPTION
- supports non JSON request bodies

Hey, it's me again. Canned was just updated again with a major feature - it now allows matching non-JSON request bodies. I guess a minor canned update also indicates a minor grunt-canned update (0.0.4 -> 0.1.0).
If you could publish the new version to the NPM repo that would be awesome!
Cheers.